### PR TITLE
cpp: simple-linked-list improvements

### DIFF
--- a/cpp/simple-linked-list/simple_linked_list.cpp
+++ b/cpp/simple-linked-list/simple_linked_list.cpp
@@ -1,40 +1,45 @@
 #include "simple_linked_list.h"
 
 #include <initializer_list>
+#include <algorithm>
+#include <iterator>
 #include <stdexcept>
 
 namespace simple_linked_list {
 
 List::List(std::initializer_list<int> values) {
-    for (int v : values)
-        push(v);
+    std::for_each(
+        std::rbegin(values),
+        std::rend(values),
+        [this](int v) { this->push(v); }
+    );
 }
 
-List::List(List&& other)
+List::List(List&& other) noexcept
     : head(std::move(other.head)),
       current_size(other.current_size)
 {
     other.current_size = 0;
 }
 
-List &List::operator=(List&& other) {
+List &List::operator=(List&& other) noexcept {
     current_size = other.current_size;
     head = std::move(other.head);
     other.current_size = 0;
     return *this;
 }
 
-List::~List() {
+List::~List() noexcept {
     // Guard against stack overflow!
     while (head)
         head = std::move(head->next);
 }
 
-std::size_t List::size() const {
+std::size_t List::size() const noexcept {
     return current_size;
 }
 
-void List::push(int entry) {
+void List::push(int entry) noexcept {
     auto element = std::make_unique<Element>(entry);
     head.swap(element);
     head->next = std::move(element);
@@ -51,7 +56,7 @@ int List::pop() {
     return val;
 }
 
-void List::reverse() {
+void List::reverse() noexcept {
     std::unique_ptr<Element> reversed{nullptr};
     while (head) {
         auto elem = std::move(head);
@@ -62,18 +67,18 @@ void List::reverse() {
     head = std::move(reversed);
 }
 
-bool List::empty() const {
+bool List::empty() const noexcept {
    return size() == 0;
 }
 
-const int &List::front() const {
+int List::front() const {
     if (!head)
         throw std::out_of_range("Can't look at front of an empty list!");
 
     return head->data;
 }
 
-void List::clear() {
+void List::clear() noexcept {
     while (head) {
         head = std::move(head->next);
     }

--- a/cpp/simple-linked-list/simple_linked_list.h
+++ b/cpp/simple-linked-list/simple_linked_list.h
@@ -10,23 +10,23 @@ class List {
    public:
     List() = default;
     List(std::initializer_list<int> values);
-    ~List();
+    ~List() noexcept;
 
     List(const List&) = delete;
     List& operator=(const List&) = delete;
 
-    List(List&&);
-    List& operator=(List&&);
+    List(List&&) noexcept;
+    List& operator=(List&&) noexcept;
 
-    std::size_t size() const;
-    void push(int entry);
+    std::size_t size() const noexcept;
+    void push(int entry) noexcept;
     int pop();
-    void reverse();
+    void reverse() noexcept;
 
     // Additional expected stack (linked-list) interface.
-    bool empty() const;
-    const int &front() const;
-    void clear();
+    [[nodiscard]] bool empty() const noexcept;
+    [[nodiscard]] int front() const;
+    void clear() noexcept;
 
    private:
     struct Element {

--- a/cpp/simple-linked-list/simple_linked_list_test.cpp
+++ b/cpp/simple-linked-list/simple_linked_list_test.cpp
@@ -113,7 +113,7 @@ TEST_CASE("ReverseNonEmptyList") {
 // My TESTS
 TEST_CASE("Initializer List") {
     simple_linked_list::List list{1, 2, 3};
-    for (int i = 3; i > 0; i--)
+    for (int i = 1; i < 4; i++)
         REQUIRE(list.pop() == i);
 }
 


### PR DESCRIPTION
    - noexcept, [[nodiscard]]
    - reversed order in the initializer list constructor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the order of elements when initializing the list from an initializer list, ensuring elements are now stored in the expected sequence.

- **Refactor**
  - Improved exception safety and performance by marking several methods and constructors as `noexcept`.
  - Updated method annotations to encourage proper usage and compiler optimizations.

- **Tests**
  - Adjusted tests to validate the corrected order of elements when popping from a list initialized with multiple values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->